### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fury API Blueprint Parser
 
-[![Build Status](https://img.shields.io/travis/refractproject/fury-adapter-apib-parser.svg)](https://travis-ci.org/refractproject/fury-adapter-apib-parser) [![Coverage Status](https://img.shields.io/coveralls/refractproject/fury-adapter-apib-parser.svg)](https://coveralls.io/r/refractproject/fury-adapter-apib-parser) [![NPM version](https://img.shields.io/npm/v/fury-adapter-apib-parser.svg)](https://www.npmjs.org/package/fury-adapter-apib-parser) [![License](https://img.shields.io/npm/l/fury-adapter-apib-parser.svg)](https://www.npmjs.org/package/fury-adapter-apib-parser)
+[![Build Status](https://img.shields.io/travis/apiaryio/fury-adapter-apib-parser.svg)](https://travis-ci.org/apiaryio/fury-adapter-apib-parser) [![Coverage Status](https://img.shields.io/coveralls/apiaryio/fury-adapter-apib-parser.svg)](https://coveralls.io/r/apiaryio/fury-adapter-apib-parser) [![NPM version](https://img.shields.io/npm/v/fury-adapter-apib-parser.svg)](https://www.npmjs.org/package/fury-adapter-apib-parser) [![License](https://img.shields.io/npm/l/fury-adapter-apib-parser.svg)](https://www.npmjs.org/package/fury-adapter-apib-parser)
 
 This adapter provides support for parsing [API Blueprint](https://apiblueprint.org/) in [Fury.js](https://github.com/apiaryio/fury.js) using the Node binding [Protagonist](https://github.com/apiaryio/protagonist) of [Drafter](https://github.com/apiaryio/drafter).
 


### PR DESCRIPTION
This project is under the `apiaryio` org instead of `refractproject`, so a couple of badges are wrong.
