### PR TITLE
Add `requireBlueprintName` option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 0.4.0 - 2016-10-27
+
+## Enhancement
+
+- Adds support for the `requireBlueprintName` option during parsing. This
+  option will validate that the blueprint has a name.
+
 # 0.3.0 - 2016-07-19
 
 ### Enhancement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "API Blueprint parser for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -15,10 +15,11 @@ export function detect(source) {
 /*
  * Parse an API Blueprint into refract elements.
  */
-export function parse({source, generateSourceMap}, done) {
+export function parse({source, generateSourceMap, requireBlueprintName}, done) {
   const options = {
     exportSourcemap: !!generateSourceMap,
     type: 'refract',
+    requireBlueprintName,
   };
 
   drafter.parse(source, options, done);

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -48,4 +48,14 @@ describe('API Blueprint parser adapter', () => {
       expect(filtered[0]).to.be.an.object;
     });
   });
+
+  it('can parse an API Blueprint with require blueprint name', (done) => {
+    const source = '# GET /\n+ Response 204\n';
+
+    adapter.parse({source, requireBlueprintName: true}, (err, output) => {
+      expect(err).not.to.be.null;
+      expect(output.content[0].element).to.equal('annotation');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Adds support for the `requireBlueprintName` option during parsing. This option will validate that the blueprint has a name. This option is already found in the underlying parser.
