### PR TITLE
Markdown suffix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 0.6.0 - 2016-11-16
+
+## Enhancement
+
+- Adds support for `markdown` suffix in apiblueprint content type;
+
 # 0.5.0 - 2016-10-31
 
 ## Enhancement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "API Blueprint parser for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.20",
-    "deckardcain": "^0.1.6",
+    "deckardcain": "^0.3.2",
     "drafter": "^1.2.0"
   },
   "devDependencies": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -6,6 +6,7 @@ import drafter from 'drafter';
 export const name = 'api-blueprint';
 export const mediaTypes = [
   'text/vnd.apiblueprint',
+  'text/vnd.apiblueprint+markdown',
 ];
 
 export function detect(source) {


### PR DESCRIPTION
Because Apiary is using it and since we are not modifying the content type before sending it to fury, we need this.