### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.10.0
+
+## Enhancements
+
+- Compatibility with [Minim 0.20.1](https://github.com/refractproject/minim/releases/tag/v0.20.1)
+  and [Fury 3.0.0 Beta 6](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.6).
+
 # 0.9.0
 
 - Compatibility with [Minim 0.19](https://github.com/refractproject/minim/releases/tag/v0.19.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "API Blueprint parser for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {
@@ -19,15 +19,15 @@
     "babel-runtime": "^6.23.0",
     "deckardcain": "^0.3.2",
     "drafter": "^1.2.0",
-    "minim": "^0.19.0"
+    "minim": "^0.20.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.4"
+    "fury": "3.0.0-beta.6"
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "fury": "^3.0.0-beta.4",
-    "peasant": "^1.1.0"
+    "fury": "^3.0.0-beta.6",
+    "peasant": "1.1.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Compatibility with [Minim 0.20.1](https://github.com/refractproject/minim/releases/tag/v0.20.1) and [Fury 3.0.0 Beta 6](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.6).