### PR TITLE
Update to fury 3.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.11.0
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Enhancements
+
+- Compatibility with [Fury 3.0.0 Beta 7](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.7).
+
 # 0.10.0
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "babel-runtime": "^6.23.0",
     "deckardcain": "^0.3.2",
     "drafter": "^1.2.0",
-    "minim": "^0.20.1"
+    "minim": "^0.20.5"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.6"
+    "fury": "3.0.0-beta.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "fury": "^3.0.0-beta.6",
+    "fury": "3.0.0-beta.7",
     "peasant": "1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-parser",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "API Blueprint parser for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {


### PR DESCRIPTION
Adds compatibility with [Fury 3.0.0 Beta 7](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.7).