### PR TITLE
Allow users to override drafter. Default to drafter.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,27 @@ npm install fury-adapter-apib-parser
 import fury from 'fury';
 import apibParser from 'fury-adapter-apib-parser';
 
-fury.use(apibParser);
+fury.use(apibParser());
+
+fury.parse({source: '... your API Blueprint ...'}, (err, result) => {
+  if (err) {
+    console.log(err);
+    return;
+  }
+
+  // The returned `result` is a Minim parse result element.
+  console.log(result.api.title);
+});
+```
+
+For better performance, a C++ version of the Blueprint parser can be used.
+
+```js
+import fury from 'fury';
+import apibParser from 'fury-adapter-apib-parser';
+import drafter from 'drafter';
+
+fury.use(apibParser(drafter));
 
 fury.parse({source: '... your API Blueprint ...'}, (err, result) => {
   if (err) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "deckardcain": "^0.4.0",
-    "drafter": "^1.2.0",
+    "drafter.js": "^2.6.7",
     "minim": "^0.21.1"
   },
   "peerDependencies": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,53 +1,55 @@
 // API Blueprint parser for Fury.js
 
 import deckardcain from 'deckardcain';
-import drafter from 'drafter';
+import drafterJs from 'drafter.js';
 import { JSON06Serialiser } from 'minim';
 
-export const name = 'api-blueprint';
-export const mediaTypes = [
+const name = 'api-blueprint';
+const mediaTypes = [
   'text/vnd.apiblueprint',
   'text/vnd.apiblueprint+markdown',
 ];
 
-export function detect(source) {
+function detect(source) {
   return mediaTypes.indexOf(deckardcain.identify(source)) !== -1;
 }
 
-export function validate({ minim, source, requireBlueprintName }, done) {
-  const options = {
-    requireBlueprintName,
-  };
+export default function (drafter = drafterJs) {
+  function validate({ minim, source, requireBlueprintName }, done) {
+    const options = {
+      requireBlueprintName,
+    };
 
-  const serialiser = new JSON06Serialiser(minim);
+    const serialiser = new JSON06Serialiser(minim);
 
-  drafter.validate(source, options, (err, parseResult) => {
-    if (parseResult) {
-      done(err, serialiser.deserialise(parseResult));
-    } else {
-      done(err, parseResult);
-    }
-  });
+    drafter.validate(source, options, (err, parseResult) => {
+      if (parseResult) {
+        done(err, serialiser.deserialise(parseResult));
+      } else {
+        done(err, parseResult);
+      }
+    });
+  }
+
+  /*
+   * Parse an API Blueprint into refract elements.
+   */
+  function parse({ minim, source, generateSourceMap, requireBlueprintName }, done) {
+    const options = {
+      exportSourcemap: !!generateSourceMap,
+      requireBlueprintName,
+    };
+
+    const serialiser = new JSON06Serialiser(minim);
+
+    drafter.parse(source, options, (err, parseResult) => {
+      if (parseResult) {
+        done(err, serialiser.deserialise(parseResult));
+      } else {
+        done(err, parseResult);
+      }
+    });
+  }
+
+  return { name, mediaTypes, detect, validate, parse };
 }
-
-/*
- * Parse an API Blueprint into refract elements.
- */
-export function parse({ minim, source, generateSourceMap, requireBlueprintName }, done) {
-  const options = {
-    exportSourcemap: !!generateSourceMap,
-    requireBlueprintName,
-  };
-
-  const serialiser = new JSON06Serialiser(minim);
-
-  drafter.parse(source, options, (err, parseResult) => {
-    if (parseResult) {
-      done(err, serialiser.deserialise(parseResult));
-    } else {
-      done(err, parseResult);
-    }
-  });
-}
-
-export default { name, mediaTypes, detect, validate, parse };

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -4,7 +4,9 @@
  */
 
 import { expect } from 'chai';
-import { parse, detect } from '../src/adapter';
+import adapter from '../src/adapter';
+
+const { parse, detect } = adapter();
 
 describe('API Blueprint parser adapter', () => {
   context('detection', () => {
@@ -56,5 +58,18 @@ describe('API Blueprint parser adapter', () => {
       expect(output.content[0].element).to.equal('annotation');
       done();
     });
+  });
+
+  it('works with protagonist', (done) => {
+    const source = '# GET /\n+ Response 204\n';
+
+    const fakeParse = adapter({ parse(a, b, c) {
+      expect(a).to.equal(source);
+      expect(b).to.deep.equal({ exportSourcemap: false, requireBlueprintName: true });
+      c();
+      done();
+    } }).parse;
+
+    fakeParse({ source, requireBlueprintName: true }, () => {});
   });
 });

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
 import { Namespace } from 'minim';
-import { validate } from '../src/adapter';
+import adapter from '../src/adapter';
+
+const { validate } = adapter();
 
 const minim = new Namespace();
 


### PR DESCRIPTION
This PR changes the default version of drafter used to `drafter.js` but allows users to override it with the C++ version.

**This is a breaking change.**

Related issues and pull requests
* apiaryio/dredd#1184
* apiaryio/dredd#1168
* apiaryio/dredd-transactions#196